### PR TITLE
Refactor to modular design with IPC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.pkl
+*.json
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # Savvy Desktop App
+
+This application demonstrates a semantic search desktop UI built with [Flet](https://flet.dev/).
+
+## Running
+
+Install dependencies and run the app:
+
+```bash
+pip install -r requirements.txt
+python main.py
+```
+
+The application expects `data.json` and `vector_index.pkl` in the same directory.
+
+## Code Structure
+
+- `data_loader.py` – loads the semantic model and data files.
+- `search.py` – implements search utilities.
+- `ipc.py` – launches a background process for search operations.
+- `ui.py` – UI logic using Flet.
+- `main.py` – entry point which starts the UI and search worker.

--- a/data_loader.py
+++ b/data_loader.py
@@ -1,0 +1,32 @@
+import json
+import pickle
+import logging
+from sentence_transformers import SentenceTransformer
+
+MODEL = None
+SOFTWARE_DATA = {}
+VECTOR_INDEX = {}
+_top_tags = []
+
+
+def load_data_and_model():
+    """Load semantic model and data files."""
+    global MODEL, SOFTWARE_DATA, VECTOR_INDEX, _top_tags
+    logging.info("Loading semantic search model (SentenceTransformer)...")
+    try:
+        MODEL = SentenceTransformer('all-MiniLM-L6-v2')
+    except Exception as e:
+        logging.error(f"Failed to load SentenceTransformer model: {e}")
+        return False
+
+    logging.info("Attempting to load data.json and vector_index.pkl...")
+    try:
+        with open("data.json", 'r', encoding='utf-8') as f:
+            SOFTWARE_DATA = json.load(f)
+        with open("vector_index.pkl", "rb") as f:
+            VECTOR_INDEX = pickle.load(f)
+        _top_tags[:] = VECTOR_INDEX.get('top_tags', [])
+    except (FileNotFoundError, Exception) as e:
+        logging.error(f"Data file loading error: {e}")
+        return False
+    return True

--- a/ipc.py
+++ b/ipc.py
@@ -1,0 +1,39 @@
+import multiprocessing
+from typing import Any, Dict, List
+
+from data_loader import load_data_and_model
+import search
+
+
+class SearchWorker:
+    def __init__(self):
+        self.request_q: multiprocessing.Queue = multiprocessing.Queue()
+        self.response_q: multiprocessing.Queue = multiprocessing.Queue()
+        self.proc = multiprocessing.Process(target=self._worker, daemon=True)
+        self.proc.start()
+
+    def _worker(self):
+        if not load_data_and_model():
+            self.response_q.put({'error': 'load_failed'})
+            return
+        while True:
+            message = self.request_q.get()
+            if message.get('type') == 'stop':
+                break
+            query = message.get('query', '')
+            if query.lower().startswith('tag:'):
+                tag = query.split(':', 1)[1]
+                results = search.perform_tag_filter(tag)
+            elif query:
+                results = search.perform_search(query)
+            else:
+                results = search.get_default_results()
+            self.response_q.put(results)
+
+    def search(self, query: str) -> List[Dict[str, Any]]:
+        self.request_q.put({'type': 'search', 'query': query})
+        return self.response_q.get()
+
+    def close(self):
+        self.request_q.put({'type': 'stop'})
+        self.proc.join()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,8 @@
+import flet as ft
+from ipc import SearchWorker
+from ui import main as ui_main
+
+if __name__ == "__main__":
+    search_worker = SearchWorker()
+    ft.app(target=lambda page: ui_main(page, search_worker), assets_dir="assets")
+    search_worker.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+flet
+sentence-transformers
+scikit-learn
+numpy
+

--- a/search.py
+++ b/search.py
@@ -1,0 +1,110 @@
+import re
+from datetime import datetime
+from typing import List, Dict, Any, Optional
+
+import numpy as np
+from sklearn.metrics.pairwise import cosine_similarity
+
+from data_loader import MODEL, SOFTWARE_DATA, VECTOR_INDEX
+
+
+def perform_search(query: str) -> List[Dict[str, Any]]:
+    if not query or not MODEL or not VECTOR_INDEX or not SOFTWARE_DATA:
+        return []
+    query_embedding = MODEL.encode(query, convert_to_tensor=False)
+    similarities = cosine_similarity([query_embedding], VECTOR_INDEX['embeddings'])[0]
+    top_indices = np.argsort(similarities)[-50:][::-1]
+    results = []
+    for idx in top_indices:
+        if similarities[idx] > 0.3:
+            metadata_id = VECTOR_INDEX['metadata'][idx]
+            key, version_idx_str = metadata_id.split('::')
+            version_idx = int(version_idx_str)
+            version_data = SOFTWARE_DATA[key]['Versions'][version_idx].copy()
+            version_data['SoftwareTitle'] = SOFTWARE_DATA[key]['Title']
+            version_data['__metadata_id'] = metadata_id
+            results.append(version_data)
+    return results
+
+
+def perform_tag_filter(tag: str) -> List[Dict[str, Any]]:
+    tag_map = VECTOR_INDEX.get("tag_map", {})
+    if not tag or not tag_map or not SOFTWARE_DATA:
+        return []
+    lower_tag = tag.lower()
+    matching_ids = [metadata_id for metadata_id, tags in tag_map.items() if lower_tag in tags]
+    results = []
+    for metadata_id in matching_ids:
+        try:
+            key, version_idx_str = metadata_id.split('::')
+            version_idx = int(version_idx_str)
+            software_info = SOFTWARE_DATA[key]
+            version_data = software_info['Versions'][version_idx]
+            result_item = version_data.copy()
+            result_item['SoftwareTitle'] = software_info.get('Title', key)
+            result_item['__metadata_id'] = metadata_id
+            results.append(result_item)
+        except (KeyError, IndexError, ValueError):
+            continue
+    return results
+
+
+def find_related_packages(target_pkg_data: dict, count: int = 4) -> List[Dict[str, Any]]:
+    target_metadata_id = target_pkg_data.get('__metadata_id')
+    if not target_metadata_id or not MODEL or not VECTOR_INDEX or not SOFTWARE_DATA:
+        return []
+    try:
+        target_idx = VECTOR_INDEX['metadata'].index(target_metadata_id)
+        target_embedding = VECTOR_INDEX['embeddings'][target_idx]
+    except (ValueError, IndexError):
+        return []
+    similarities = cosine_similarity([target_embedding], VECTOR_INDEX['embeddings'])[0]
+    top_indices = np.argsort(similarities)[-(count+1):][::-1]
+    results = []
+    for idx in top_indices:
+        metadata_id = VECTOR_INDEX['metadata'][idx]
+        if metadata_id == target_metadata_id:
+            continue
+        key, version_idx_str = metadata_id.split('::')
+        version_idx = int(version_idx_str)
+        version_data = SOFTWARE_DATA[key]['Versions'][version_idx].copy()
+        version_data['SoftwareTitle'] = SOFTWARE_DATA[key]['Title']
+        version_data['__metadata_id'] = metadata_id
+        results.append(version_data)
+        if len(results) == count:
+            break
+    return results
+
+
+def get_default_results() -> List[Dict[str, Any]]:
+    if not SOFTWARE_DATA or not VECTOR_INDEX:
+        return []
+    indexed_packages = []
+    for metadata_id in VECTOR_INDEX['metadata']:
+        try:
+            key, version_idx_str = metadata_id.split('::')
+            version_idx = int(version_idx_str)
+            software_info = SOFTWARE_DATA[key]
+            version_data = software_info['Versions'][version_idx].copy()
+            version_data['SoftwareTitle'] = software_info.get('Title', key)
+            version_data['__metadata_id'] = metadata_id
+            indexed_packages.append(version_data)
+        except (KeyError, IndexError, ValueError):
+            continue
+    indexed_packages.sort(key=lambda v: int(re.search(r'\((\d+)\)', v.get("LastUpdated", "/Date(0)/")).group(1) or 0), reverse=True)
+    return indexed_packages[:50]
+
+
+def format_timestamp(date_str: Optional[str]) -> str:
+    if not date_str:
+        return "N/A"
+    match = re.search(r'\((\d+)\)', date_str)
+    if match:
+        timestamp_ms = match.group(1)
+        if timestamp_ms:
+            timestamp = int(timestamp_ms) / 1000
+            try:
+                return datetime.fromtimestamp(timestamp).strftime('%d %B %Y')
+            except (ValueError, OSError):
+                return "Invalid Date"
+    return "Invalid Date"


### PR DESCRIPTION
## Summary
- split monolithic `Main.py` into modules
- add IPC search worker process
- create simple entry point `main.py`
- document running steps and code layout
- add basic repo hygiene files

## Testing
- `python -m py_compile main.py ui.py data_loader.py ipc.py search.py`

------
https://chatgpt.com/codex/tasks/task_e_688a75e2d0408328b58b665e8fa77b66